### PR TITLE
Fix incorrect namespace for VAV in Example dataset

### DIFF
--- a/sample_building_sol.ttl
+++ b/sample_building_sol.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:AHU-1 a brick:AHU ;
-    bf:feeds brick:VAV-2150 ;
+    bf:feeds ex:VAV-2150 ;
     bf:isLocatedIn ex:Room-B100 .
 
 ex:ZNT-2150 a brick:Zone_Temperature_Sensor ;


### PR DESCRIPTION
Following query won't work with current turtle file.

```
PREFIX brick: <https://brickschema.org/schema/1.0.1/Brick#>
PREFIX bf: <https://brickschema.org/schema/1.0.1/BrickFrame#>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX : <undefined>
PREFIX example: <http://example.com#>
PREFIX ex: <http://example.org/>

SELECT ?sensor ?type
WHERE{
  ?sensor bf:isPointOf ?vav .
  ?ahu bf:feeds ?vav .
  ?vav bf:feeds ?zone .
  ?sensor bf:isPointOf ?vav .
  ?sensor rdf:type ?type
}
```

due to AHU feeding into brick:VAV-2150 instead of ex:VAV-2150